### PR TITLE
add apt-get update to pre_tasks

### DIFF
--- a/graphite-grafana.yml
+++ b/graphite-grafana.yml
@@ -2,6 +2,11 @@
 - name: graphite-grafana
   hosts: graphite-grafana
   sudo: yes
+
+  pre_tasks:
+    - name: apt-get update
+      apt: update_cache=yes
+
   roles:
     - role: nginx
       nginx_events_params:


### PR DESCRIPTION
This pre_task updates apt to avoid  `E: Unable to fetch some archives` 
errors when doing the initial `vagrant up` with this configuration.
