### PR TITLE
Fix the ansible 2.x syntax for expressing with_item using variables

### DIFF
--- a/roles/nginx/tasks/configuration.yml
+++ b/roles/nginx/tasks/configuration.yml
@@ -20,26 +20,26 @@
 
 - name: Ensure auth_basic files created
   template: src=auth_basic.j2 dest={{nginx_conf_dir}}/auth_basic/{{ item }} owner=root group={{nginx_group}} mode=0750
-  with_items: nginx_auth_basic_files.keys()
+  with_items: "{{ nginx_auth_basic_files.keys() }}"
   tags: [configuration,nginx]
 
 - name: Create the configurations for sites
   template: src=site.conf.j2 dest={{nginx_conf_dir}}/sites-available/{{ item }}.conf
-  with_items: nginx_sites.keys()
+  with_items: "{{ nginx_sites.keys() }}"
   notify: 
    - restart nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
   file: state=link src={{nginx_conf_dir}}/sites-available/{{ item }}.conf dest={{nginx_conf_dir}}/sites-enabled/{{ item }}.conf
-  with_items: nginx_sites.keys()
+  with_items: "{{ nginx_sites.keys() }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]
 
 - name: Create the configurations for independent config file
   template: src=config.conf.j2 dest={{nginx_conf_dir}}/conf.d/{{ item }}.conf
-  with_items: nginx_configs.keys()
+  with_items: "{{ nginx_configs.keys() }}"
   notify:
    - reload nginx
   tags: [configuration,nginx]

--- a/roles/nginx/tasks/installation.packages.yml
+++ b/roles/nginx/tasks/installation.packages.yml
@@ -11,26 +11,26 @@
 
 - name: Install the nginx packages
   yum: name={{ item }} state=present disablerepo='*' enablerepo={{ "nginx," if nginx_official_repo else "" }}{{ yum_epel_repo }},{{ yum_base_repo }}
-  with_items: nginx_redhat_pkg
+  with_items: "{{ nginx_redhat_pkg }}"
   when:  nginx_is_el|bool
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   yum: name={{ item }} state=present
-  with_items: nginx_redhat_pkg
+  with_items: "{{ nginx_redhat_pkg }}"
   when: ansible_os_family == "RedHat" and not nginx_is_el|bool
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   apt: name={{ item }} state=present
-  with_items: nginx_ubuntu_pkg
+  with_items: "{{ nginx_ubuntu_pkg }}"
   environment: "{{ nginx_env }}"
   when: ansible_os_family == "Debian"
   tags: [packages,nginx]
 
 - name: Install the nginx packages
   pkgng: name={{ item }} state=present
-  with_items: nginx_freebsd_pkg
+  with_items: "{{ nginx_freebsd_pkg }}"
   environment: "{{ nginx_env }}"
   when: ansible_os_family == "FreeBSD"
   tags: [packages,nginx]


### PR DESCRIPTION
Tested and validated on Mac with Ansible 2.2.0.0 and with Vagrant Ubuntu (that's in your file).
Not tested with the redhat install path but "should" be the same "{{ }}" syntax